### PR TITLE
Revert "Deploy only merged pull request"

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,8 +1,7 @@
 on:
-    pull_request:
+    push:
         branches:
             - ja
-        types: [closed]
 
 name: CD
 
@@ -12,7 +11,7 @@ jobs:
 
         runs-on: ubuntu-latest
 
-        if: "!contains(github.event.head_commit.message, 'auto rebuilding site') && github.event.pull_request.merged == true"
+        if: "!contains(github.event.head_commit.message, 'auto rebuilding site')"
 
         steps:
             -   name: "Checkout"


### PR DESCRIPTION
Reverts okazy/symfony-docs#2

github pages を ja ブランチの最新に合わせたかったので以前の仕様に戻す